### PR TITLE
repeat is now saved as a number

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -33,5 +33,5 @@
     "activeTab",
     "storage"
   ],
-  "version": "1.4.6"
+  "version": "1.4.7"
 }

--- a/options.js
+++ b/options.js
@@ -75,8 +75,10 @@ function collectConfig() {
 			var check = mainTableBody.rows[row].querySelector('.activ').checked || false ;
 			var repeat = mainTableBody.rows[row].querySelector('.repeat').value || 0 ;
 			var delay = mainTableBody.rows[row].querySelector('.delay').value || 0;
-			if(url_regex !== '' && ses !== '' && isNumeric(delay)) {
+
+			if(url_regex !== '' && ses !== '' && isNumeric(delay) && isNumeric(repeat)) {
 				delay = parseInt(delay);
+				repeat = parseInt(repeat);
 				feeds.push({
 					'activ': check,
 					'annotation': desc, 


### PR DESCRIPTION
For some reason, repeat was correctly saved when debugging locally, but it is broken in the released version. This PR fixes that issue.